### PR TITLE
ADD functionality to change tracking url for certain page types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	"require":
 	{
 		"silverstripe/framework": "3.0.*",
-		"silverstripe/multisites": "*",
+		"silverstripe-australia/silverstripe-multisites": "*",
 		"composer/installers": "*"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 
 	"require":
 	{
-		"silverstripe/framework": "3.0.*",
+		"silverstripe/framework": ">=3.0",
 		"silverstripe-australia/silverstripe-multisites": "*",
 		"composer/installers": "*"
 	}

--- a/javascript/event-tracking-universal.js
+++ b/javascript/event-tracking-universal.js
@@ -2,7 +2,7 @@
 
 	$(document).ready(function() {
 	
-		var filetypes = /\.(zip|exe|dmg|pdf|doc.*|xls.*|ppt.*|mp3|txt|rar|wma|mov|avi|wmv|flv|wav)$/i;
+		var filetypes = /\.(js|css|bmp|png|gif|jpg|jpeg|ico|pcx|tif|tiff|au|mid|midi|mpa|mp3|ogg|m4a|ra|wma|wav|cda|avi|mpg|mpeg|asf|wmv|m4v|mov|mkv|mp4|ogv|webm|swf|flv|ram|rm|doc|docx|txt|rtf|xls|xlsx|pages|ppt|pptx|pps|csv|cab|arj|tar|zip|zipx|sit|sitx|gz|tgz|bz2|ace|arc|pkg|dmg|hqx|jar|xml|pdf|gpx|kml)$/i;
 		var baseHref = '';
 		if ($('base').attr('href') != undefined) baseHref = $('base').attr('href');
 		var hrefRedirect = '';

--- a/javascript/event-tracking-universal.js
+++ b/javascript/event-tracking-universal.js
@@ -1,17 +1,21 @@
 (function($) {
 
+	// add window.location.origin for browsers that don't support it yet
+	if (!window.location.origin) {
+		window.location.origin = window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '');
+	}
+
 	$(document).ready(function() {
-	
+		
 		var filetypes = /\.(js|css|bmp|png|gif|jpg|jpeg|ico|pcx|tif|tiff|au|mid|midi|mpa|mp3|ogg|m4a|ra|wma|wav|cda|avi|mpg|mpeg|asf|wmv|m4v|mov|mkv|mp4|ogv|webm|swf|flv|ram|rm|doc|docx|txt|rtf|xls|xlsx|pages|ppt|pptx|pps|csv|cab|arj|tar|zip|zipx|sit|sitx|gz|tgz|bz2|ace|arc|pkg|dmg|hqx|jar|xml|pdf|gpx|kml)$/i;
-		var baseHref = '';
-		if ($('base').attr('href') != undefined) baseHref = $('base').attr('href');
+		var baseHref = ($('base').attr('href') != undefined) ? $('base').attr('href') : document.location.origin;
 		var hrefRedirect = '';
 	 
 		$('body').on('click', 'a', function(event) {
 			var el = $(this);
 			var track = true;
 			var href = (typeof(el.attr('href')) != 'undefined' ) ? el.attr('href') : '';
-			var isThisDomain = href.match(document.domain.split('.').reverse()[1] + '.' + document.domain.split('.').reverse()[0]);
+			var isExternal = href.match(/^https?\:/i) && href.indexOf(baseHref) < 0;
 			if (!href.match(/^javascript:/i)) {
 				var elEv = []; elEv.value=0, elEv.non_i=false;
 				if (href.match(/^mailto\:/i)) {
@@ -20,12 +24,18 @@
 					elEv.label = href.replace(/^mailto\:/i, '');
 					elEv.loc = href;
 				}
+				else if (href.match(/^tel\:/i)) {
+					elEv.category = 'telephone';
+					elEv.action = 'click';
+					elEv.label = href.replace(/^tel\:/i, '');
+					elEv.loc = href;
+				}
 				else if (href.match(filetypes)) {
 					var extension = (/[.]/.exec(href)) ? /[^.]+$/.exec(href) : undefined;
 					elEv.category = 'download';
 					elEv.action = 'click-' + extension[0];
 					elEv.label = href.replace(/ /g,'-');
-					elEv.loc = baseHref + href;
+					elEv.loc = ((!isExternal && !href.match(/^https?\:/i)) ? baseHref : '') + href;
 				}
 				else if (el.hasClass('download')) { 
 					// extra for dms module. 
@@ -34,19 +44,13 @@
 					elEv.category = 'download';
 					elEv.action = 'click-' + el.data('extension');
 					elEv.label = el.data('filename');
-					elEv.loc = baseHref + href;
+					elEv.loc = ((!isExternal && !href.match(/^https?\:/i)) ? baseHref : '') + href;
 				}
-				else if (href.match(/^https?\:/i) && !isThisDomain) {
+				else if (isExternal) {
 					elEv.category = 'external';
 					elEv.action = 'click';
 					elEv.label = href.replace(/^https?\:\/\//i, '');
 					elEv.non_i = true;
-					elEv.loc = href;
-				}
-				else if (href.match(/^tel\:/i)) {
-					elEv.category = 'telephone';
-					elEv.action = 'click';
-					elEv.label = href.replace(/^tel\:/i, '');
 					elEv.loc = href;
 				}
 				else track = false;

--- a/javascript/event-tracking.js
+++ b/javascript/event-tracking.js
@@ -1,16 +1,20 @@
 (function($) {
 
+	// add window.location.origin for browsers that don't support it yet
+	if (!window.location.origin) {
+		window.location.origin = window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '');
+	}
+
 	$(document).ready(function() {
 	
 		var filetypes = /\.(js|css|bmp|png|gif|jpg|jpeg|ico|pcx|tif|tiff|au|mid|midi|mpa|mp3|ogg|m4a|ra|wma|wav|cda|avi|mpg|mpeg|asf|wmv|m4v|mov|mkv|mp4|ogv|webm|swf|flv|ram|rm|doc|docx|txt|rtf|xls|xlsx|pages|ppt|pptx|pps|csv|cab|arj|tar|zip|zipx|sit|sitx|gz|tgz|bz2|ace|arc|pkg|dmg|hqx|jar|xml|pdf|gpx|kml)$/i;
-		var baseHref = '';
-		if ($('base').attr('href') != undefined) baseHref = $('base').attr('href');
+		var baseHref = ($('base').attr('href') != undefined) ? $('base').attr('href') : document.location.origin;
 		 
 		$('a').on('click', function(event) {
 			var el = $(this);
 			var track = true;
 			var href = (typeof(el.attr('href')) != 'undefined' ) ? el.attr('href') :"";
-			var isThisDomain = href.match(document.domain.split('.').reverse()[1] + '.' + document.domain.split('.').reverse()[0]);
+			var isExternal = href.match(/^https?\:/i) && href.indexOf(baseHref) < 0;
 			if (!href.match(/^javascript:/i)) {
 				var elEv = []; elEv.value=0, elEv.non_i=false;
 				if (href.match(/^mailto\:/i)) {
@@ -19,12 +23,18 @@
 					elEv.label = href.replace(/^mailto\:/i, '');
 					elEv.loc = href;
 				}
+				else if (href.match(/^tel\:/i)) {
+					elEv.category = "telephone";
+					elEv.action = "click";
+					elEv.label = href.replace(/^tel\:/i, '');
+					elEv.loc = href;
+				}
 				else if (href.match(filetypes)) {
 					var extension = (/[.]/.exec(href)) ? /[^.]+$/.exec(href) : undefined;
 					elEv.category = "download";
 					elEv.action = "click-" + extension[0];
 					elEv.label = href.replace(/ /g,"-");
-					elEv.loc = baseHref + href;
+					elEv.loc = ((!isExternal && !href.match(/^https?\:/i)) ? baseHref : '') + href;
 				}
 				else if (el.hasClass('download')) { 
 					// extra for dms module. 
@@ -33,19 +43,13 @@
 					elEv.category = 'download';
 					elEv.action = 'click-' + el.data('extension');
 					elEv.label = el.data('filename');
-					elEv.loc = baseHref + href;
+					elEv.loc = ((!isExternal && !href.match(/^https?\:/i)) ? baseHref : '') + href;
 				}
-				else if (href.match(/^https?\:/i) && !isThisDomain) {
+				else if (isExternal) {
 					elEv.category = "external";
 					elEv.action = "click";
 					elEv.label = href.replace(/^https?\:\/\//i, '');
 					elEv.non_i = true;
-					elEv.loc = href;
-				}
-				else if (href.match(/^tel\:/i)) {
-					elEv.category = "telephone";
-					elEv.action = "click";
-					elEv.label = href.replace(/^tel\:/i, '');
 					elEv.loc = href;
 				}
 				else track = false;

--- a/javascript/event-tracking.js
+++ b/javascript/event-tracking.js
@@ -2,7 +2,7 @@
 
 	$(document).ready(function() {
 	
-		var filetypes = /\.(zip|exe|dmg|pdf|doc.*|xls.*|ppt.*|mp3|txt|rar|wma|mov|avi|wmv|flv|wav)$/i;
+		var filetypes = /\.(js|css|bmp|png|gif|jpg|jpeg|ico|pcx|tif|tiff|au|mid|midi|mpa|mp3|ogg|m4a|ra|wma|wav|cda|avi|mpg|mpeg|asf|wmv|m4v|mov|mkv|mp4|ogv|webm|swf|flv|ram|rm|doc|docx|txt|rtf|xls|xlsx|pages|ppt|pptx|pps|csv|cab|arj|tar|zip|zipx|sit|sitx|gz|tgz|bz2|ace|arc|pkg|dmg|hqx|jar|xml|pdf|gpx|kml)$/i;
 		var baseHref = '';
 		if ($('base').attr('href') != undefined) baseHref = $('base').attr('href');
 		 


### PR DESCRIPTION
Added method to controller extension that returns a custom url for the GA page view. Can be overwritten by page types that allow different views on the same URL, i.e. multi step forms where all steps use the same URL.
